### PR TITLE
Fix acceptance tests

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -111,7 +111,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     cmd_ismaster = 'db.isMaster().ismaster'
     cmd_ismaster = mongorc_file + cmd_ismaster if mongorc_file
     db = 'admin'
-    res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.chomp
+    res = mongo_cmd(db, conn_string, cmd_ismaster).to_s.split(%r{\n}).last.chomp
     res.eql?('true')
   end
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -26,9 +26,11 @@ class mongodb::server::install {
     }
   }
 
-  package { 'mongodb_server':
-    ensure => $my_package_ensure,
-    name   => $package_name,
-    tag    => 'mongodb_package',
+  unless defined(Package[$package_name]) {
+    package { 'mongodb_server':
+      ensure => $my_package_ensure,
+      name   => $package_name,
+      tag    => 'mongodb_package',
+    }
   }
 }

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -58,7 +58,10 @@ describe 'mongodb::mongos class' do
   describe 'uninstalling' do
     it 'uninstalls mongodb' do
       pp = <<-EOS
-        class { 'mongodb::server':
+        class { 'mongodb::mongos':
+          package_ensure => 'purged',
+        }
+        -> class { 'mongodb::server':
           ensure         => absent,
           package_ensure => absent,
           service_ensure => stopped,
@@ -66,9 +69,6 @@ describe 'mongodb::mongos class' do
         }
         -> class { 'mongodb::client':
           ensure => absent,
-        }
-        -> class { 'mongodb::mongos':
-          package_ensure => 'purged',
         }
       EOS
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper_acceptance'
 
 describe 'mongodb::mongos class' do
- 
   case fact('osfamily')
   when 'Debian'
     package_name = 'mongodb-server'
     config_file  = '/etc/mongodb-shard.conf'
-  else   
+  else
     package_name = 'mongodb-org-server'
     config_file  = '/etc/mongos.conf'
   end

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -16,10 +16,13 @@ describe 'mongodb::mongos class' do
       pp = <<-EOS
         class { 'mongodb::server':
           configsvr => true,
+          replset   => 'test',
+          replset_members => ['127.0.0.1:27019'],
+          port      => 27019,
         }
         -> class { 'mongodb::client': }
         -> class { 'mongodb::mongos':
-          configdb => ['127.0.0.1:27019'],
+          configdb => ['test/127.0.0.1:27019'],
         }
       EOS
 

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -85,12 +85,23 @@ describe 'mongodb::server class' do
       pp = <<-EOS
         class { 'mongodb::server':
           auth           => true,
-          create_admin   => true,
+          create_admin   => false,
+          handle_creds   => true,
           store_creds    => true,
           admin_username => 'admin',
-          admin_password => 'password'
+          admin_password => 'password',
+          restart        => true,
+          set_parameter  => ['enableLocalhostAuthBypass: true']
         }
         class { 'mongodb::client': }
+
+        mongodb_user { "User admin on db admin":
+          ensure        => present,
+          password_hash => mongodb_password('admin', 'password'),
+          username      => 'admin',
+          database      => 'admin',
+          roles         => ['dbAdmin', 'userAdminAnyDatabase'],
+        }
       EOS
 
       apply_manifest(pp, catch_failures: true)

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -9,10 +9,10 @@ describe 'mongodb::mongos' do
       when 'Debian'
         package_name = 'mongodb-server'
         config_file  = '/etc/mongodb-shard.conf'
-      else   
+      else
         package_name = 'mongodb-org-mongos'
         config_file  = '/etc/mongos.conf'
-      end      
+      end
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
#### Pull Request (PR) description

This is the fix for the failing mongos acceptance tests. At some point (I believe mongo 3.4) mongos started to require an initialized replica set to start, so the earlier manifest no longer works.

Tested with:

```shell
$ export BEAKER_setfile="centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}" BEAKER_PUPPET_COLLECTION=puppet5
$ bundle exec rake beaker
```

```shell
$ export BEAKER_setfile="centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}" BEAKER_PUPPET_COLLECTION=puppet6
$ bundle exec rake beaker
```

```shell
$ export BEAKER_setfile="centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}" BEAKER_PUPPET_COLLECTION=puppet7
$ bundle exec rake beaker
```


```shell
$ export BEAKER_setfile="centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}" BEAKER_PUPPET_COLLECTION=puppet7
$ bundle exec rake beaker
```

```shell
$ bundle exec rake rubocop
```

It also now passes with the following sets:

* `debian9-64{hostname=debian9-64.example.com}`
* `ubuntu1804-64{hostname=ubuntu1804-64.example.com}`

#### This Pull Request (PR) fixes the following issues

voxpupuli/puppet-mongodb/pull/606
